### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/black.yml
+++ b/.github/workflows/black.yml
@@ -5,6 +5,9 @@ jobs:
   linter_name:
     name: runner / black
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
     steps:
       - uses: actions/checkout@v4
       - name: Check files using the black formatter


### PR DESCRIPTION
Potential fix for [https://github.com/Alcheri/Dictionary/security/code-scanning/2](https://github.com/Alcheri/Dictionary/security/code-scanning/2)

To fix the problem, explicitly scope the `GITHUB_TOKEN` permissions for this workflow to the minimum needed. For a linting workflow that runs Black and then opens/updates a pull request with `peter-evans/create-pull-request`, the job needs to be able to push commits and manage PRs, but it does not need broader write access.

The safest change, without altering existing behavior, is to add a `permissions` block for the `linter_name` job specifying:
- `contents: write` (to create a branch and push formatted changes)
- `pull-requests: write` (to open/update the PR)

This should be added under `linter_name:` alongside `runs-on:` so it applies only to this job. No other parts of the workflow need to change, and no imports or external libraries are involved, since this is a YAML workflow configuration.

Concretely, in `.github/workflows/black.yml`, between `runs-on: ubuntu-latest` (line 7) and `steps:` (line 8), insert:

```yaml
    permissions:
      contents: write
      pull-requests: write
```

This limits the `GITHUB_TOKEN` to only what is necessary for the Black auto-formatting PR behavior to continue working.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
